### PR TITLE
Double-dash custom selector syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,11 +42,6 @@
     "test": "vitest",
     "test:update": "vitest -u"
   },
-  "release": {
-    "branches": [
-      "main"
-    ]
-  },
   "devDependencies": {
     "@tailwindcss/postcss": "4.0.0-beta.3",
     "@tailwindcss/vite": "4.0.0-beta.3",

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
+export default {
+  branches: ['master'],
+};

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -6,4 +6,4 @@ export const CSS_IMPORT_PATTERN = /@import\s+('|")(?<file>[^("|')]*)('|")/;
 
 export const VARIANT_ATRULE_PATTERN = /@variant\s+(?<name>.*[^\s])\s+\((?<selectors>.*[^;|\s])\)/;
 
-export const VARIANT_SELECTOR_PATTERN = /:variant\((.*[^)])\)/;
+export const VARIANT_SELECTOR_PATTERN = /:--([^\s]*)/;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,9 +1,9 @@
-export const CSS_FILE_PATTERN = /.*\.(css|scss)$/;
+export const CSS_FILE_PATTERN = /.*\.(css|scss|sass|pcss|postcss)$/;
 
-export const CSS_ENTRY_PATTERN = /^((?!\?svelte&type=style).)+\.(css|scss)$/;
+export const CSS_ENTRY_PATTERN = /^((?!\?svelte&type=style).)+\.(css|scss|sass|pcss|postcss)$/;
 
 export const CSS_IMPORT_PATTERN = /@import\s+('|")(?<file>[^("|')]*)('|")/;
 
-export const VARIANT_ATRULE_PATTERN = /@variant\s+(?<name>.*[^\s])\s+\((?<selectors>.*[^;|\s])\)/;
+export const VARIANT_ATRULE_PATTERN = /@variant\s+(?<name>[^\s]*)\s+\((?<selectors>.*[^;])\)/;
 
 export const VARIANT_SELECTOR_PATTERN = /:--([^\s]*)/;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -6,4 +6,4 @@ export const CSS_IMPORT_PATTERN = /@import\s+('|")(?<file>[^("|')]*)('|")/;
 
 export const VARIANT_ATRULE_PATTERN = /@variant\s+(?<name>[^\s]*)\s+\((?<selectors>.*[^;])\)/;
 
-export const VARIANT_SELECTOR_PATTERN = /:--([^\s]*)/;
+export const VARIANT_SELECTOR_PATTERN = /:--([^\s(){};:>|+,~]*)/;

--- a/test/index.css
+++ b/test/index.css
@@ -4,11 +4,11 @@
   .valid {
     color: black;
 
-    &:variant(singlepseudoclass) {
+    &:--singlepseudoclass {
       color: red;
     }
 
-    &:variant(singlepseudoelement) {
+    &:--singlepseudoelement {
       color: pink;
     }
   }

--- a/test/variants.css
+++ b/test/variants.css
@@ -5,3 +5,4 @@
 @variant singlepseudoelement (&::after);
 @variant multipseudoelement (&::after, &::before);
 @variant multimixed (&::after, &.foo);
+@variant mediaquery (@media (min-width: 600px));


### PR DESCRIPTION
This PR implements straightforwardly a switch to use the double-dash syntax as outlined in the csswg's extension spec. Closes #1.